### PR TITLE
[cmake]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# cmake
+
+CMake is an open-source, cross-platform family of tools designed to build, test and package software
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.cmake?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # cmake
 
 CMake is an open-source, cross-platform family of tools designed to build, test and package software

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/cmake'

--- a/controls/cmake_exists.rb
+++ b/controls/cmake_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm cmake exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cmake')
+ 
+control 'core-plans-cmake-exists' do
+  impact 1.0
+  title 'Ensure cmake exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/cmake')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/cmake_exists.rb
+++ b/controls/cmake_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-cmake-exists' do
   impact 1.0
   title 'Ensure cmake exists'
   desc '
-  '
+  Verify cmake by ensuring /bin/cmake exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/cmake_works.rb
+++ b/controls/cmake_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm cmake works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cmake')
+
+control 'core-plans-cmake-works' do
+  impact 1.0
+  title 'Ensure cmake works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} cmake --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /cmake version #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/cmake_works.rb
+++ b/controls/cmake_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-cmake-works' do
   impact 1.0
   title 'Ensure cmake works as expected'
   desc '
+  Verify cmake by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: cmake
+title: Habitat Core Plan cmake
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan cmake
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/patches/000-disable_test_file_access.patch
+++ b/patches/000-disable_test_file_access.patch
@@ -1,0 +1,23 @@
+--- Source/kwsys/testSystemTools.cxx.bak	2019-04-19 18:02:02.444485000 +0000
++++ Source/kwsys/testSystemTools.cxx	2019-04-19 18:02:41.633482000 +0000
+@@ -328,13 +328,13 @@
+   }
+ 
+   // While we're at it, check proper TestFileAccess functionality.
+-  if (kwsys::SystemTools::TestFileAccess(testNewFile,
+-                                         kwsys::TEST_FILE_WRITE)) {
+-    std::cerr
+-      << "TestFileAccess incorrectly indicated that this is a writable file:"
+-      << testNewFile << std::endl;
+-    res = false;
+-  }
++  //if (kwsys::SystemTools::TestFileAccess(testNewFile,
++                                         //kwsys::TEST_FILE_WRITE)) {
++    //std::cerr
++      //<< "TestFileAccess incorrectly indicated that this is a writable file:"
++      //<< testNewFile << std::endl;
++    //res = false;
++  //}
+ 
+   if (!kwsys::SystemTools::TestFileAccess(testNewFile, kwsys::TEST_FILE_OK)) {
+     std::cerr

--- a/patches/001-disable-failing-bundleutlities-tests.patch
+++ b/patches/001-disable-failing-bundleutlities-tests.patch
@@ -1,0 +1,131 @@
+--- Tests/BundleUtilities/CMakeLists.txt.orig	2019-04-19 20:53:10.039589000 +0000
++++ Tests/BundleUtilities/CMakeLists.txt	2019-04-19 20:53:45.869185000 +0000
+@@ -18,65 +18,69 @@
+ set_target_properties(shared shared2 framework PROPERTIES
+                       SKIP_BUILD_RPATH 1)
+ 
+-
+-######  test a Bundle application using dependencies
+-
+-# a loadable module (depends on shared2)
+-# testbundleutils1 will load this at runtime
+-add_library(module1 MODULE module.cpp module.h)
+-set_target_properties(module1 PROPERTIES PREFIX "")
+-target_link_libraries(module1 shared2)
+-
+-# a bundle application
+-add_executable(testbundleutils1 MACOSX_BUNDLE testbundleutils1.cpp)
+-target_link_libraries(testbundleutils1 shared framework ${CMAKE_DL_LIBS})
+-
+-set_target_properties(testbundleutils1 module1 PROPERTIES
+-                      INSTALL_RPATH "${CMAKE_CURRENT_BINARY_DIR}/testdir1"
+-                      BUILD_WITH_INSTALL_RPATH 1)
+-
+-# add custom target to install and test the app
+-add_custom_target(testbundleutils1_test  ALL
+-  COMMAND ${CMAKE_COMMAND}
+-  "-DINPUT=$<TARGET_FILE:testbundleutils1>"
+-  "-DMODULE=$<TARGET_FILE:module1>"
+-  "-DINPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
+-  "-DOUTPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/testdir1"
+-  -P "${CMAKE_CURRENT_SOURCE_DIR}/bundleutils.cmake"
+-  DEPENDS testbundleutils1 module1
+-  )
+-
+-add_dependencies(testbundleutils1_test testbundleutils1)
+-
+-
+-
+-######  test a non-Bundle application using dependencies
+-
+-# a loadable module (depends on shared2)
+-# testbundleutils2 will load this at runtime
+-add_library(module2 MODULE module.cpp module.h)
+-set_target_properties(module2 PROPERTIES PREFIX "")
+-target_link_libraries(module2 shared2)
+-
+-# a non-bundle application
+-add_executable(testbundleutils2 testbundleutils2.cpp)
+-target_link_libraries(testbundleutils2 shared framework ${CMAKE_DL_LIBS})
+-
+-set_target_properties(testbundleutils2 module2 PROPERTIES
+-                      INSTALL_RPATH "${CMAKE_CURRENT_BINARY_DIR}/testdir2"
+-                      BUILD_WITH_INSTALL_RPATH 1)
+-
+-# add custom target to install and test the app
+-add_custom_target(testbundleutils2_test  ALL
+-  COMMAND ${CMAKE_COMMAND}
+-  "-DINPUT=$<TARGET_FILE:testbundleutils2>"
+-  "-DMODULE=$<TARGET_FILE:module2>"
+-  "-DINPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
+-  "-DOUTPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/testdir2"
+-  -P "${CMAKE_CURRENT_SOURCE_DIR}/bundleutils.cmake"
+-  DEPENDS testbundleutils1 module2
+-  )
+-add_dependencies(testbundleutils2_test testbundleutils2)
++# The following two tests will always fail in Habitat
++# They have an expectation that there will be no
++# "external" dependencies, which is always faled due to
++# how we utilize LD_RUN_PATH to control runtime linking
++#
++# ######  test a Bundle application using dependencies
++#
++# # a loadable module (depends on shared2)
++# # testbundleutils1 will load this at runtime
++# add_library(module1 MODULE module.cpp module.h)
++# set_target_properties(module1 PROPERTIES PREFIX "")
++# target_link_libraries(module1 shared2)
++# 
++# # a bundle application
++# add_executable(testbundleutils1 MACOSX_BUNDLE testbundleutils1.cpp)
++# target_link_libraries(testbundleutils1 shared framework ${CMAKE_DL_LIBS})
++# 
++# set_target_properties(testbundleutils1 module1 PROPERTIES
++# INSTALL_RPATH "${CMAKE_CURRENT_BINARY_DIR}/testdir1"
++# BUILD_WITH_INSTALL_RPATH 1)
++# 
++# # add custom target to install and test the app
++# add_custom_target(testbundleutils1_test  ALL
++# COMMAND ${CMAKE_COMMAND}
++# "-DINPUT=$<TARGET_FILE:testbundleutils1>"
++# "-DMODULE=$<TARGET_FILE:module1>"
++# "-DINPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
++# "-DOUTPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/testdir1"
++# -P "${CMAKE_CURRENT_SOURCE_DIR}/bundleutils.cmake"
++# DEPENDS testbundleutils1 module1
++# )
++# 
++# add_dependencies(testbundleutils1_test testbundleutils1)
++# 
++# 
++# 
++# ######  test a non-Bundle application using dependencies
++# 
++# # a loadable module (depends on shared2)
++# # testbundleutils2 will load this at runtime
++# add_library(module2 MODULE module.cpp module.h)
++# set_target_properties(module2 PROPERTIES PREFIX "")
++# target_link_libraries(module2 shared2)
++# 
++# # # a non-bundle application
++# add_executable(testbundleutils2 testbundleutils2.cpp)
++# target_link_libraries(testbundleutils2 shared framework ${CMAKE_DL_LIBS})
++# 
++# set_target_properties(testbundleutils2 module2 PROPERTIES
++# INSTALL_RPATH "${CMAKE_CURRENT_BINARY_DIR}/testdir2"
++# BUILD_WITH_INSTALL_RPATH 1)
++# 
++# # add custom target to install and test the app
++# add_custom_target(testbundleutils2_test  ALL
++# COMMAND ${CMAKE_COMMAND}
++# "-DINPUT=$<TARGET_FILE:testbundleutils2>"
++# "-DMODULE=$<TARGET_FILE:module2>"
++# "-DINPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
++# "-DOUTPUTDIR=${CMAKE_CURRENT_BINARY_DIR}/testdir2"
++# -P "${CMAKE_CURRENT_SOURCE_DIR}/bundleutils.cmake"
++# DEPENDS testbundleutils1 module2
++# )
++# add_dependencies(testbundleutils2_test testbundleutils2)
+ 
+ 
+ if(APPLE AND NOT CMAKE_SYSTEM_VERSION VERSION_LESS 9.0)

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,24 @@
+$pkg_name="cmake"
+$pkg_origin="core"
+$base_version="3.17"
+$pkg_version="$base_version.2"
+$pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
+$pkg_upstream_url="https://cmake.org/"
+$pkg_license=@("BSD-3-Clause")
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_source="http://cmake.org/files/v$base_version/cmake-$pkg_version-win64-x64.msi"
+$pkg_shasum="06e999be9e50f9d33945aeae698b9b83678c3f98cedb3139a84e19636d2f6433"
+$pkg_build_deps=@("core/lessmsi")
+$pkg_bin_dirs=@("bin")
+
+function Invoke-Unpack {
+    mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    try {
+        lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+    } finally { Pop-Location }
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/cmake-$pkg_version-win64-x64/SourceDir/cmake/*" "$pkg_prefix" -Recurse -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,54 @@
+pkg_name=cmake
+pkg_origin=core
+_base_version=3.17
+pkg_version=${_base_version}.2
+pkg_maintainer='The Habitat Maintainers <humans@habitat.sh>'
+pkg_license=('BSD-3-Clause')
+pkg_description="CMake is an open-source, cross-platform family of tools designed to build, test and package software"
+pkg_upstream_url="https://cmake.org/"
+pkg_source="https://cmake.org/files/v${_base_version}/cmake-${pkg_version}.tar.gz"
+pkg_shasum=fc77324c4f820a09052a7785549b8035ff8d3461ded5bbd80d252ae7d1cd3aa5
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/curl
+  core/zlib
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/make
+  core/gcc
+  core/patch
+)
+
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_bin_dirs=(bin)
+
+do_prepare() {
+  # This disables a test that incorrectly detects that a file has write access
+  patch -p0 < "$PLAN_CONTEXT"/patches/000-disable_test_file_access.patch
+  # This disables two tests that will always fail in a Habitat build environment
+  patch -p0 < "$PLAN_CONTEXT"/patches/001-disable-failing-bundleutlities-tests.patch
+}
+
+do_build() {
+  ZLIB=$(pkg_path_for core/zlib)
+  ZLIB_LIB="${ZLIB}/lib"
+  ZLIB_INCLUDE="${ZLIB}/include"
+  CURL=$(pkg_path_for core/curl)
+  CURL_LIB="${CURL}/lib"
+  CURL_INCLUDE="${CURL}/include"
+
+  ./bootstrap --parallel="$(nproc)" --system-curl -- \
+    -DZLIB_LIBRARY:FILEPATH="${ZLIB_LIB}/libz.so" -DZLIB_INCLUDE_DIR:PATH="${ZLIB_INCLUDE}" \
+    -DCURL_LIBRARY:FILEPATH="${CURL_LIB}/libcurl.so"  -DCURL_INCLUDE_DIR:PATH="${CURL_INCLUDE}"
+
+  ./configure --prefix="${pkg_prefix}"
+  make -j "$(nproc)"
+}
+
+do_check() {
+  make test
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+@test "Version matches plan" {
+  TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" cmake --version | grep 'cmake version' | awk '{print $3}')"
+  diff <( echo "$actual_version" ) <( echo "${TEST_PKG_VERSION}" )
+}

--- a/tests/test.pester.ps1
+++ b/tests/test.pester.ps1
@@ -1,0 +1,15 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/cmake" {
+    Context "cmake" {
+        $OutputVariable = (hab pkg exec $PackageIdentifier cmake --version | Out-String)
+        $OutputVariable -match  "(?<=cmake version )([0-9\.]*)"
+        It "returns --version that matches the plan" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path       = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier =$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://9575daeb13902b2e6fd41ef057351e0960fb7352b354cecedf5d04c7cdf7cdb6 --input-file /src/attributes.yml

Profile: Habitat Core Plan cmake (cmake)
Version: 0.1.0
Target:  docker://9575daeb13902b2e6fd41ef057351e0960fb7352b354cecedf5d04c7cdf7cdb6

  ✔  core-plans-cmake-works: Ensure cmake works as expected
     ✔  Command: `hab pkg path core/cmake` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/cmake` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/cmake/3.17.2/20200603132255 cmake --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/cmake/3.17.2/20200603132255 cmake --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/cmake/3.17.2/20200603132255 cmake --version` stdout is expected to match /cmake version 3.17.2/
     ✔  Command: `DEBUG=true; hab pkg exec core/cmake/3.17.2/20200603132255 cmake --version` stderr is expected to be empty
  ✔  core-plans-cmake-exists: Ensure cmake exists
     ✔  File /hab/pkgs/core/cmake/3.17.2/20200603132255/bin/cmake is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[7][default:/src:0]# 
```